### PR TITLE
Various Fixes and Hot Reloading on Filtering

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -413,7 +413,7 @@ function getCountryCode() {
 function setProviderId(id) {
   provider_id = Number(id);
   storeSettings(country_code, provider_id, filterStatus);
-  //reloadMovieFilter();
+  reloadMovieFilter();
 }
 
 /**
@@ -451,6 +451,7 @@ function getFilterStatus() {
 function setFilterStatus(status) {
   filterStatus = status;
   storeSettings(country_code, provider_id, filterStatus);
+  reloadMovieFilter();
 }
 
 /**
@@ -461,7 +462,7 @@ function setFilterStatus(status) {
 function setCountryCode(code) {
   country_code = code;
   storeSettings(country_code, provider_id, filterStatus);
-  //reloadMovieFilter();
+  reloadMovieFilter();
 }
 
 /**
@@ -480,7 +481,7 @@ function reloadMovieFilter() {
         url: tab.url
       };
 
-      //unfadeUnstreamedMovies(tabId, crawledMovies[tabId]);
+      unfadeUnstreamedMovies(tabId, crawledMovies[tabId]);
       checkForLetterboxd(tabId, changeInfo, tabInfo);
     }
   }

--- a/extension/background.js
+++ b/extension/background.js
@@ -50,20 +50,20 @@ const onStartUp = async () => {
     let providerSet = false;
     let statusSet = false;
 
-    if(item.hasOwnProperty('country_code')) {
+    if (item.hasOwnProperty('country_code')) {
       countrySet = true;
       setCountryCode(item.country_code);
     }
-    if(item.hasOwnProperty('provider_id')) {
+    if (item.hasOwnProperty('provider_id')) {
       providerSet = true;
       setProviderId(item.provider_id);
     }
-    if(item.hasOwnProperty('filterStatus')) {
+    if (item.hasOwnProperty('filterStatus')) {
       statusSet = true;
       setFilterStatus(item.filterStatus);
     }
 
-    if((!countrySet) || (!providerSet) || (!statusSet)) {
+    if ((!countrySet) || (!providerSet) || (!statusSet)) {
       loadDefaultSettings(countrySet, providerSet, statusSet);
     }
   }
@@ -74,33 +74,33 @@ const onStartUp = async () => {
       // Parse JSON string into object
       response = JSON.parse(response);
       // set the intern settings
-      if(!providerSet) {
+      if (!providerSet) {
         setProviderId(response.provider_id);
       }
-      if(!countrySet) {
+      if (!countrySet) {
         setCountryCode(response.country_code);
       }
-      if(!statusSet) {
+      if (!statusSet) {
         setFilterStatus(response.filterStatus);
       }
     });
   }
 
   // load TMDb key
-  loadJSON("settings/api.json", function(response) {
+  loadJSON("settings/api.json", function (response) {
     // Parse JSON string into object
     response = JSON.parse(response);
     tmdb_key = response.tmdb;
   });
 
   // load provider list
-  loadJSON("streaming-providers/providers.json", function(response) {
+  loadJSON("streaming-providers/providers.json", function (response) {
     // Parse JSON string into object
     providers = JSON.parse(response);
   });
 
   // load country list
-  loadJSON("streaming-providers/countries.json", function(response) {
+  loadJSON("streaming-providers/countries.json", function (response) {
     // Parse JSON string into object
     countries = JSON.parse(response);
   });
@@ -161,7 +161,7 @@ async function isIncluded(tabId, toFind) {
     movie_release_year = parseInt(movie_release_year);
   }
 
-  var param = eng_title.replace(' ', '+');
+  var title_sanitized = encodeURIComponent(eng_title);
   var title_rsp = '';
   var rsp = "";
   var original_title = '';
@@ -169,8 +169,13 @@ async function isIncluded(tabId, toFind) {
 
   var xhttp = new XMLHttpRequest();
 
-  xhttp.open('GET', "https://apis.justwatch.com/content/titles/" + country_code + "/popular?body=%7B%22age_certifications%22:null,%22content_types%22:null,%22genres%22:null,%22languages%22:null,%22max_price%22:null,%22min_price%22:null,%22page%22:1,%22page_size%22:30,%22presentation_types%22:null,%22providers%22:null,%22query%22:%22" + param + "%22,%22release_year_from%22:null,%22release_year_until%22:null,%22scoring_filter_types%22:null,%22timeline_type%22:null%7D", true);
+  let justwatchRequest = {
+    page: 1,
+    page_size: 30,
+    query: title_sanitized,
+  };
 
+  xhttp.open('GET', "https://apis.justwatch.com/content/titles/" + country_code + "/popular?body=" + JSON.stringify(justwatchRequest), true);
   xhttp.send();
 
   xhttp.onreadystatechange = function () {
@@ -186,10 +191,8 @@ async function isIncluded(tabId, toFind) {
         }
       } else {
         found_perfect_match = false;
-        param = eng_title.replace(' ', '%20');
 
-        xhttp.open('GET', "https://api.themoviedb.org/3/search/movie?api_key=" + getAPIKey() + "&query=" + param, true);
-
+        xhttp.open('GET', "https://api.themoviedb.org/3/search/movie?api_key=" + getAPIKey() + "&query=" + title_sanitized, true);
         xhttp.send();
 
         xhttp.onreadystatechange = function () {
@@ -199,45 +202,44 @@ async function isIncluded(tabId, toFind) {
             var rslt = getOriginalTitleWithReleaseYear(tabId, title_rsp, eng_title, movie_release_year);
             found_perfect_match = rslt.found_perfect_match;
 
-            if(found_perfect_match) {
+            if (found_perfect_match) {
               original_title = rslt.original_title;
-            }
-
-            if (!found_perfect_match) {
+            } else {
               original_title = getOriginalTitleWithoutExactReleaseYear(tabId, title_rsp, eng_title, movie_release_year);
             }
 
-            found_perfect_match = false;
+            if (original_title) {
+              found_perfect_match = false;
 
-            param = eng_title.replace(' ', '+');
+              title_sanitized = encodeURIComponent(original_title);
+              justwatchRequest.query = title_sanitized;
 
-            xhttp = new XMLHttpRequest();
+              xhttp = new XMLHttpRequest();
+              xhttp.open('GET', "https://apis.justwatch.com/content/titles/" + country_code + "/popular?body=" + JSON.stringify(justwatchRequest), true);
+              xhttp.send();
 
-            xhttp.open('GET', "https://apis.justwatch.com/content/titles/" + country_code + "/popular?body=%7B%22age_certifications%22:null,%22content_types%22:null,%22genres%22:null,%22languages%22:null,%22max_price%22:null,%22min_price%22:null,%22page%22:1,%22page_size%22:30,%22presentation_types%22:null,%22providers%22:null,%22query%22:%22" + param + "%22,%22release_year_from%22:null,%22release_year_until%22:null,%22scoring_filter_types%22:null,%22timeline_type%22:null%7D", true);
+              xhttp.onreadystatechange = function () {
+                if (xhttp.readyState === 4 && xhttp.status === 200) {
+                  rsp = JSON.parse(xhttp.response);
+                  found_perfect_match = getOffersWithReleaseYear(tabId, rsp, movie_letterboxd_id, original_title, movie_release_year);
 
-            xhttp.send();
+                  if (!found_perfect_match) {
+                    getOffersWithoutExactReleaseYear(tabId, rsp, movie_letterboxd_id, original_title, movie_release_year);
+                  }
 
-            xhttp.onreadystatechange = function () {
-              if (xhttp.readyState === 4 && xhttp.status === 200) {
-                rsp = JSON.parse(xhttp.response);
-                found_perfect_match = getOffersWithReleaseYear(tabId, rsp, movie_letterboxd_id, original_title, movie_release_year);
+                  checkCounter[tabId]++;
 
-                if (!found_perfect_match) {
-                  getOffersWithoutExactReleaseYear(tabId, rsp, movie_letterboxd_id, original_title, movie_release_year);
+                  if (checkCounter[tabId] === Object.keys(crawledMovies[tabId]).length) {
+                    fadeUnstreamedMovies(tabId, crawledMovies[tabId]);
+                  }
+                } else if (xhttp.readyState === 4 && xhttp.status !== 200) {
+                  checkCounter[tabId]++;
+                  if (checkCounter[tabId] === Object.keys(crawledMovies[tabId]).length) {
+                    fadeUnstreamedMovies(tabId, crawledMovies[tabId]);
+                  }
                 }
-
-                checkCounter[tabId]++;
-
-                if (checkCounter[tabId] === Object.keys(crawledMovies[tabId]).length) {
-                  fadeUnstreamedMovies(tabId, crawledMovies[tabId]);
-                }
-              } else if (xhttp.readyState === 4 && xhttp.status !== 200) {
-                checkCounter[tabId]++;
-                if (checkCounter[tabId] === Object.keys(crawledMovies[tabId]).length) {
-                  fadeUnstreamedMovies(tabId, crawledMovies[tabId]);
-                }
-              }
-            };
+              };
+            }
           } else if (xhttp.readyState === 4 && xhttp.status === 429) {
             checkCounter[tabId]++;
             unsolvedRequests[tabId][toFind.title] = {
@@ -351,8 +353,8 @@ function getOriginalTitleWithReleaseYear(tabId, title_rsp, eng_title, movie_rele
  */
 function getOriginalTitleWithoutExactReleaseYear(tabId, title_rsp, eng_title, movie_release_year) {
   for (let item in title_rsp.results) {
-    if (title_rsp.results[item].title.toLowerCase() === eng_title.toLowerCase()
-      && ((movie_release_year === -1) || (title_rsp.results[item].release_date.includes(movie_release_year - 1)) || (title_rsp.results[item].release_date.includes(movie_release_year + 1)))) {
+    if (title_rsp.results[item].title.toLowerCase() === eng_title.toLowerCase() &&
+      ((movie_release_year === -1) || (title_rsp.results[item].release_date.includes(movie_release_year - 1)) || (title_rsp.results[item].release_date.includes(movie_release_year + 1)))) {
       return title_rsp.results[item].original_title;
     }
   }
@@ -501,7 +503,7 @@ function getAPIKey() {
  * @param {object} tabInfo - The tabInfo from the tabs.onUpdated event.
  */
 function checkForLetterboxd(tabId, changeInfo, tabInfo) {
-  if(filterStatus) {
+  if (filterStatus) {
     if (changeInfo.hasOwnProperty('status') && changeInfo.status === 'complete') {
       var url = tabInfo.url;
       if (url.includes("://letterboxd.com/") || url.includes("://www.letterboxd.com/")) {
@@ -533,9 +535,9 @@ function handleMessage(request, sender, sendResponse) {
     console.log("Error: missing TabId");
   }
   if (request.hasOwnProperty('message_type')) {
-    if(request.message_type === 'movie-titles') {
+    if (request.message_type === 'movie-titles') {
       crawledMovies[tabId] = request.message_content;
-      if(Object.keys(crawledMovies[tabId]).length === 0) {
+      if (Object.keys(crawledMovies[tabId]).length === 0) {
         getFilmsFromLetterboxd(tabId);
       } else {
         checkMovieAvailability(tabId, crawledMovies[tabId]);
@@ -551,9 +553,9 @@ function handleMessage(request, sender, sendResponse) {
  * @param {object} movies - The crawled movies from Letterboxed.
  */
 function checkMovieAvailability(tabId, movies) {
-  if(filterStatus) {
+  if (filterStatus) {
     prepareLetterboxdForFading(tabId);
-    for(let movie in movies) {
+    for (let movie in movies) {
       var inc = isIncluded(tabId, {
         title: movie,
         year: movies[movie].year,
@@ -570,12 +572,12 @@ function checkMovieAvailability(tabId, movies) {
  */
 function prepareLetterboxdForFading(tabId) {
   browser.tabs.insertCSS(tabId, {
-      file: "./style/hideunstreamed.css"
+    file: "./style/hideunstreamed.css"
   });
 
   browser.tabs.executeScript(tabId, {
-      code: "document.body.className = document.body.className + ' hide-films-unstreamed';",
-      allFrames: false
+    code: "document.body.className = document.body.className + ' hide-films-unstreamed';",
+    allFrames: false
   });
 }
 
@@ -590,15 +592,15 @@ function fadeUnstreamedMovies(tabId, movies) {
     unfadeAllMovies(tabId);
 
     var className = '';
-    if(tab.url.includes('watchlist')) {
+    if (tab.url.includes('watchlist')) {
       className = 'poster-container';
     } else {
       className = 'film-poster';
     }
 
-    for(let movie in movies) {
+    for (let movie in movies) {
       for (let movie_id in movies[movie].id) {
-        if(!availableMovies[tabId].includes(movies[movie].id[movie_id])) {
+        if (!availableMovies[tabId].includes(movies[movie].id[movie_id])) {
           browser.tabs.executeScript(tabId, {
             code: "filmposters = document.body.getElementsByClassName('" + className + "'); \n" +
               "filmposters[" + movies[movie].id[movie_id] + "].className = filmposters[" + movies[movie].id[movie_id] + "].className + ' film-not-streamed';",
@@ -609,15 +611,15 @@ function fadeUnstreamedMovies(tabId, movies) {
     }
 
     // short delay for the overview page, needs to reload intern javascript
-    if(tab.url.includes('letterboxd.com/films/')) {
+    if (tab.url.includes('letterboxd.com/films/')) {
       setTimeout(function () {
         fadeUnstreamedMovies(tabId, movies);
       }, 500);
     }
 
     // if there are unsolved requests left: solve them
-    if(Object.keys(unsolvedRequests[tabId]).length !== 0) {
-      if(isNaN(unsolvedRequestsDelay)) {
+    if (Object.keys(unsolvedRequests[tabId]).length !== 0) {
+      if (isNaN(unsolvedRequestsDelay)) {
         unsolvedRequestsDelay = 10000;
       }
 
@@ -676,7 +678,7 @@ function unfadeUnstreamedMovies(tabId, movies) {
         if (!availableMovies[tabId].includes(movies[movie].id[movie_id])) {
           browser.tabs.executeScript(tabId, {
             code: "filmposters = document.body.getElementsByClassName('" + className + "'); \n" +
-            "filmposters[" + movies[movie].id[movie_id] + "].className = filmposters[" + movies[movie].id[movie_id] + "].className.replace(' film-not-streamed', '');",
+              "filmposters[" + movies[movie].id[movie_id] + "].className = filmposters[" + movies[movie].id[movie_id] + "].className.replace(' film-not-streamed', '');",
             allFrames: false
           });
         }

--- a/extension/streaming-providers/providers.json
+++ b/extension/streaming-providers/providers.json
@@ -15,7 +15,7 @@
     "countries": ["de", "us", "uk", "at", "jp"]
   },
   "mubi": {
-    "provder_id": 11,
+    "provider_id": 11,
     "name": "Mubi",
     "countries": ["ca", "us", "mx", "uk", "de", "at", "fr", "es", "ch", "jp"]
   },
@@ -60,7 +60,7 @@
     "countries": ["mx", "us"]
   },
   "alleskino": {
-    "provder_id": 33,
+    "provider_id": 33,
     "name": "Alleskino",
     "countries": ["de", "at", "ch"]
   },
@@ -75,7 +75,7 @@
     "countries": ["de", "uk", "at", "fr", "es", "ch"]
   },
   "now_tv": {
-    "provder_id": 39,
+    "provider_id": 39,
     "name": "Now TV",
     "countries": ["uk"]
   },
@@ -90,27 +90,27 @@
     "countries": ["fr"]
   },
   "canal_play": {
-    "provder_id": 57,
+    "provider_id": 57,
     "name": "Canal Play",
     "countries": ["fr"]
   },
   "atres_player": {
-    "provder_id": 62,
+    "provider_id": 62,
     "name": "Atres Player",
     "countries": ["es"]
   },
   "filmin": {
-    "provder_id": 63,
+    "provider_id": 63,
     "name": "Filmin",
     "countries": ["es"]
   },
   "flimin_plus": {
-    "provder_id": 64,
+    "provider_id": 64,
     "name": "Filmin Plus",
     "countries": ["es"]
   },
   "filmin_latino": {
-    "provder_id": 66,
+    "provider_id": 66,
     "name": "Filmin Latino",
     "countries": []
   },
@@ -135,7 +135,7 @@
     "countries": ["jp"]
   },
   "kividoo": {
-    "provder_id": 89,
+    "provider_id": 89,
     "name": "Kividoo",
     "countries": ["de", "at", "ch"]
   },
@@ -145,17 +145,17 @@
     "countries": ["us", "ca", "uk", "de", "at"]
   },
   "guidedoc": {
-    "provder_id": 100,
+    "provider_id": 100,
     "name": "GuideDoc",
     "countries": ["ca", "us", "uk", "de", "at", "es", "ch"]
   },
   "all_4": {
-    "provder_id": 103,
+    "provider_id": 103,
     "name": "All 4",
     "countries": ["uk"]
   },
   "hbo_espana": {
-    "provder_id": 118,
+    "provider_id": 118,
     "name": "HBO",
     "countries": ["es"]
   },
@@ -165,12 +165,12 @@
     "countries": ["ca", "mx", "fr", "es", "ch"]
   },
   "fxnow": {
-    "provder_id": 123,
+    "provider_id": 123,
     "name": "FXNow",
     "countries": ["us"]
   },
   "disneylife": {
-    "provder_id": 129,
+    "provider_id": 129,
     "name": "DisneyLife",
     "countries": ["uk"]
   },
@@ -180,12 +180,12 @@
     "countries": ["fr"]
   },
   "max_go": {
-    "provder_id": 139,
+    "provider_id": 139,
     "name": "Max Go",
     "countries": ["us"]
   },
   "flimmit": {
-    "provder_id": 142,
+    "provider_id": 142,
     "name": "Flimmit",
     "countries": ["de", "at", "ch"]
   },
@@ -195,22 +195,22 @@
     "countries": ["us", "ca"]
   },
   "icitoutv": {
-    "provder_id": 146,
+    "provider_id": 146,
     "name": "iciTouTV",
     "countries": ["ca"]
   },
   "moviestar_plus": {
-    "provder_id": 149,
+    "provider_id": 149,
     "name": "Moviestar Plus",
     "countries": ["es"]
   },
   "swisscom": {
-    "provder_id": 150,
+    "provider_id": 150,
     "name": "SwissCom",
     "countries": ["ch"]
   },
   "britbox": {
-    "provder_id": 151,
+    "provider_id": 151,
     "name": "BritBox",
     "countries": ["us", "ca"]
   },
@@ -220,17 +220,17 @@
     "countries": ["mx"]
   },
   "netflix_kids": {
-    "provder_id": 175,
+    "provider_id": 175,
     "name": "Netflix Kids",
     "countries": ["us", "ca", "uk", "de", "at"]
   },
   "screambox": {
-    "provder_id": 185,
+    "provider_id": 185,
     "name": "Screambox",
     "countries": ["us"]
   },
   "youtube_premium": {
-    "provder_id": 188,
+    "provider_id": 188,
     "name": "YouTube Premium",
     "countries": ["mx", "us", "ca", "uk", "de", "at", "fr", "es", "ch"]
   },
@@ -240,32 +240,32 @@
     "countries": ["us"]
   },
   "crave_plus": {
-    "provder_id": 192,
+    "provider_id": 192,
     "name": "Crave Plus",
     "countries": ["ca"]
   },
   "sfr_play": {
-    "provder_id": 193,
+    "provider_id": 193,
     "name": "SFR Play",
     "countries": ["fr"]
   },
   "starz_amazon": {
-    "provder_id": 194,
+    "provider_id": 194,
     "name": "Starz Play Amazon Channel",
     "countries": ["uk", "de"]
   },
   "animax_plus_amazon": {
-    "provder_id": 195,
+    "provider_id": 195,
     "name": "Animax Plus Amazon Channel",
     "countries": ["de"]
   },
   "sky": {
-    "provder_id": 150,
+    "provider_id": 150,
     "name": "Sky",
     "countries": ["ch"]
   },
   "freeform": {
-    "provder_id": 211,
+    "provider_id": 211,
     "name": "Freeform",
     "countries": ["us"]
   },
@@ -275,7 +275,7 @@
     "countries": ["us", "ca"]
   },
   "bfi_player": {
-    "provder_id": 224,
+    "provider_id": 224,
     "name": "BFI Player",
     "countries": ["uk"]
   },
@@ -285,7 +285,7 @@
     "countries": ["mx"]
   },
   "crave": {
-    "provder_id": 230,
+    "provider_id": 230,
     "name": "Crave",
     "countries": ["ca"]
   }


### PR DESCRIPTION
I've fixed a typo in providers.json which causes some filters to not work.
When requesting film with special characters i.e. '&', the request would fail because it will be interpreted as a new parameter.
Also, I've enabled the hot-reloading and added it in `setFilterStatus`, too.
