### PR TITLE
Fix: Adapt DOM selectors and fading logic to new Letterboxd markup

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -593,7 +593,7 @@ function addMovieIfFlatrate(results, tabId, letterboxdId) {
 	var className = 'griditem';
 
 	function fadeOut(className, movieId) {
-		filmposters = document.body.getElementsByClassName(className);
+		const filmposters = document.body.getElementsByClassName(className);
 		filmposters[movieId].className += ' film-not-streamed';
 	}
 

--- a/extension/scripts/getFilmsFromLetterboxd.js
+++ b/extension/scripts/getFilmsFromLetterboxd.js
@@ -35,7 +35,7 @@ for (let index = 0; index < gridItems.length; index++) {
     }
   }
 
-  if (movies.hasOwnProperty(filmName)) {
+  if (Object.prototype.hasOwnProperty.call(movies, filmName)) {
     if (movies[filmName].year === -1) {
       movies[filmName].year = filmYear;
     }
@@ -47,8 +47,6 @@ for (let index = 0; index < gridItems.length; index++) {
     };
   }
 }
-
-console.log("[LSP] Crawled movies:", movies);
 
 browser.runtime.sendMessage({
   messageType: "movie-titles",


### PR DESCRIPTION
This PR updates the extension to work with the current Letterboxd DOM structure.
Fixes:

• Replaced old `.poster-container` nodes with modern `li.griditem` structure
• Updated getFilmsFromLetterboxd.js to parse titles & years from React component attributes
• Restored availability detection and fading logic

This fixes:
- Crawling returning empty objects
- No fading on watchlist tiles
- No provider filtering

Extension is now fully functional again (tested on Chrome 129).

What I did not take a look at (since the extension works again, I did not go into the .css):
• Update hideunstreamed.css to apply styling to `.griditem.film-not-streamed`. 
