### PR TITLE
Add support for selecting multiple streaming providers at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 This is an extension for common web browsers coded using the WebExtensions API.
 
 ## Main Features
-This extension adds a filter for streaming services (e.g., Netflix, Amazon Prime Video) to [Letterboxd](https://letterboxd.com/), to make it possible for you to see, which movies are included in your streaming flat rate.
+This extension adds a filter for one or more streaming services (e.g., Netflix, Amazon Prime Video) to [Letterboxd](https://letterboxd.com/), to make it possible for you to see, which movies are included in your streaming flat rate.
 
 ### How?
 The extension uses the TMDb API to access the streaming information that is provided by JustWatch.

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -47,7 +47,7 @@ html, body {
 select {
     border: 1px solid #333;
     width: 100%;
-    height: 36px;
+    height: 72px;
     padding: 0 10px;
     margin-top: 3px;
     margin-bottom: 14px;

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -35,6 +35,12 @@ html, body {
     color: #b8b8b8;
 }
 
+.instruction-text {
+    margin: 4px 0 10px 0;
+    font-size: 11px;
+    color: #888;
+}
+
 .select-box {
     margin-top: 16px;
 }
@@ -47,7 +53,7 @@ html, body {
 select {
     border: 1px solid #333;
     width: 100%;
-    height: 72px;
+    height: 36px;
     padding: 0 10px;
     margin-top: 3px;
     margin-bottom: 14px;
@@ -80,6 +86,21 @@ select:disabled {
 select option {
     color: #e8e8e8;
     background-color: #2a2a2a;
+}
+
+select[multiple] {
+    height: auto;
+    padding: 4px;
+}
+
+select[multiple] option {
+    padding: 5px 6px;
+    border-radius: 4px;
+}
+
+select[multiple] option:checked {
+    color: #ffffff;
+    background-color: #2196F3;
 }
 
 #footer {

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -26,7 +26,7 @@
     <label class="content-text" for="CountryList">Country</label>
     <select id="CountryList"></select>
     <label class="content-text" for="ProviderList">Streaming service</label>
-    <select id="ProviderList"></select>
+    <select id="ProviderList" multiple></select>
   </div>
 </section>
 

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -25,8 +25,12 @@
   <div class="select-box">
     <label class="content-text" for="CountryList">Country</label>
     <select id="CountryList"></select>
+  </div>
+
+  <div class="select-box">
     <label class="content-text" for="ProviderList">Streaming service</label>
-    <select id="ProviderList" multiple></select>
+    <div class="instruction-text">Hold Ctrl/Cmd to select multiple</div>
+    <select id="ProviderList" multiple size="8"></select>
   </div>
 </section>
 

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -124,7 +124,7 @@ function changeSelectedProviderIds() {
 			}
 		}
 	}
-	browser.storage.local.set({provider_id: selectedProviderIds[0]}); //TODO: multiple ids
+	browser.storage.local.set({selected_provider_ids: selectedProviderIds});
 }
 
 /**
@@ -148,7 +148,7 @@ function changeCountryCode() {
 
 function parseSettings(items) {
 	countryCode = items.hasOwnProperty('country_code') ? items.country_code : 'US';
-	selectedProviderIds = items.hasOwnProperty('provider_id') ? [items.provider_id] : [8]; //TODO: pass full list of selected providers
+	selectedProviderIds = items.hasOwnProperty('selected_provider_ids') ? items.selected_provider_ids : [8];
 	filterStatus = items.hasOwnProperty('filter_status') ? items.filter_status : false;
 }
 

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -63,10 +63,10 @@ function appendOptionsToCountryList() {
 
 /**
  * Appends all providers from the selected country as option to the providerList select tag.
- *
- * param {string} [defaultProviderName] - The (optional) name of the provider which is selected by default.
+ * A provider is pre-selected if its provider_id is part of the currently selected provider IDs,
+ * so selections carry over across a country change as long as the provider is offered there too.
  */
-function appendOptionsToProviderList(defaultProviderName) {
+function appendOptionsToProviderList() {
 	providerList.options.length = 0;
 	let fragment = document.createDocumentFragment();
 	let keys = Object.keys(providers).sort(function (a, b) {
@@ -82,14 +82,8 @@ function appendOptionsToProviderList(defaultProviderName) {
 			opt.textContent = providers[provider].name;
 			opt.value = provider;
 			opt.label = providers[provider].name;
-			if (typeof defaultProviderName === 'undefined') {
-				if (selectedProviderIds.includes(providers[provider].provider_id)) {
-					opt.selected = "selected";
-				}
-			} else {
-				if (providers[provider].name === defaultProviderName) {
-					opt.selected = "selected";
-				}
+			if (selectedProviderIds.includes(providers[provider].provider_id)) {
+				opt.selected = "selected";
 			}
 			fragment.appendChild(opt);
 		}
@@ -109,10 +103,16 @@ function changeFilterSwitch() {
 }
 
 /**
- * Called when the selected item in providerList is changed. Changes the provider_id in the background page.
+ * Called when the selection in providerList is changed. Stores the newly selected provider IDs.
+ * Does nothing if the list has no options yet (e.g. the provider cache hasn't loaded),
+ * so we never overwrite a stored selection with an empty one.
  */
 function changeSelectedProviderIds() {
-	selectedProviderIds = [];
+	if (providerList.options.length === 0) {
+		return;
+	}
+
+	let newSelectedProviderIds = [];
 	if (typeof providers !== 'undefined') {
 		var opt;
 		var id;
@@ -120,10 +120,11 @@ function changeSelectedProviderIds() {
 			opt = providerList.options[i];
 			id = opt.value;
 			if (opt.selected && providers.hasOwnProperty(id) && providers[id].hasOwnProperty('provider_id')) {
-				selectedProviderIds.push(providers[id].provider_id);
+				newSelectedProviderIds.push(providers[id].provider_id);
 			}
 		}
 	}
+	selectedProviderIds = newSelectedProviderIds;
 	browser.storage.local.set({selected_provider_ids: selectedProviderIds});
 }
 
@@ -146,9 +147,22 @@ function changeCountryCode() {
 	}
 }
 
+/**
+ * Parses settings from storage items.
+ * Falls back to the legacy single `provider_id` setting if `selected_provider_ids` hasn't been
+ * migrated yet; the worker performs the actual migration write.
+ *
+ * @param {object} items - Storage items containing settings.
+ */
 function parseSettings(items) {
 	countryCode = items.hasOwnProperty('country_code') ? items.country_code : 'US';
-	selectedProviderIds = items.hasOwnProperty('selected_provider_ids') ? items.selected_provider_ids : [8];
+	if (items.hasOwnProperty('selected_provider_ids')) {
+		selectedProviderIds = items.selected_provider_ids;
+	} else if (items.hasOwnProperty('provider_id')) {
+		selectedProviderIds = [items.provider_id];
+	} else {
+		selectedProviderIds = [8];
+	}
 	filterStatus = items.hasOwnProperty('filter_status') ? items.filter_status : false;
 }
 

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -5,7 +5,7 @@ var browser = chrome;
 
 var countries = {};
 var providers = {};
-var providerId = 0;
+var selectedProviderIds = [];
 var countryCode = '';
 var filterStatus = false;
 
@@ -20,7 +20,7 @@ browser.storage.local.get((items) => {
 	// load cached variables from sessionStorage
 	browser.storage.session.get((items) => {
 		parseCache(items);
-
+		
 		appendOptionsToCountryList();
 		
 		appendOptionsToProviderList();
@@ -32,7 +32,7 @@ browser.storage.local.get((items) => {
 		providerList.disabled = !filterStatus;
 		
 		filterSwitch.addEventListener("change", changeFilterSwitch);
-		providerList.addEventListener("change", changeProviderId);
+		providerList.addEventListener("change", changeSelectedProviderIds);
 		countryList.addEventListener("change", changeCountryCode);
 	});
 });
@@ -83,7 +83,7 @@ function appendOptionsToProviderList(defaultProviderName) {
 			opt.value = provider;
 			opt.label = providers[provider].name;
 			if (typeof defaultProviderName === 'undefined') {
-				if (providers[provider].provider_id === providerId) {
+				if (selectedProviderIds.includes(providers[provider].provider_id)) {
 					opt.selected = "selected";
 				}
 			} else {
@@ -111,21 +111,29 @@ function changeFilterSwitch() {
 /**
  * Called when the selected item in providerList is changed. Changes the provider_id in the background page.
  */
-function changeProviderId() {
-	let id = providerList.options[providerList.selectedIndex].value;
-	if (typeof providers !== 'undefined' && providers.hasOwnProperty(id) && providers[id].hasOwnProperty('provider_id')) {
-		providerId = providers[id].provider_id;
-		browser.storage.local.set({provider_id: providerId});
+function changeSelectedProviderIds() {
+	selectedProviderIds = [];
+	if (typeof providers !== 'undefined') {
+		var opt;
+		var id;
+		for (var i = 0; i < providerList.options.length; i++) {
+			opt = providerList.options[i];
+			id = opt.value;
+			if (opt.selected && providers.hasOwnProperty(id) && providers[id].hasOwnProperty('provider_id')) {
+				selectedProviderIds.push(providers[id].provider_id);
+			}
+		}
 	}
+	browser.storage.local.set({provider_id: selectedProviderIds[0]}); //TODO: multiple ids
 }
 
 /**
- * Called when the selected item in countryList is changed. 
+ * Called when the selected item in countryList is changed.
  * Changes the country code in the background page and forces the options in providerList to reload.
  */
 function changeCountryCode() {
 	let code = countryList.options[countryList.selectedIndex].value;
-	if (typeof countries !== 'undefined' && countries.hasOwnProperty(code) 
+	if (typeof countries !== 'undefined' && countries.hasOwnProperty(code)
 		&& countries[code].hasOwnProperty('code')) {
 		countryCode = countries[code].code;
 
@@ -133,15 +141,14 @@ function changeCountryCode() {
 			country_code: countryCode
 		});
 
-		let defaultProviderId = providerList.options[providerList.selectedIndex].label;
-		appendOptionsToProviderList(defaultProviderId);
-		changeProviderId();
+		appendOptionsToProviderList();
+		changeSelectedProviderIds();
 	}
 }
 
 function parseSettings(items) {
 	countryCode = items.hasOwnProperty('country_code') ? items.country_code : 'US';
-	providerId = items.hasOwnProperty('provider_id') ? items.provider_id : 8;
+	selectedProviderIds = items.hasOwnProperty('provider_id') ? [items.provider_id] : [8]; //TODO: pass full list of selected providers
 	filterStatus = items.hasOwnProperty('filter_status') ? items.filter_status : false;
 }
 

--- a/extension/settings/default.json
+++ b/extension/settings/default.json
@@ -1,5 +1,5 @@
 {
   "country_code": "US",
-  "provider_id": 8,
+  "selected_provider_ids": [8],
   "filter_status": false
 }

--- a/extension/worker.js
+++ b/extension/worker.js
@@ -114,14 +114,14 @@ async function requestProviderList() {
  */
 async function parseSettings(items) {
 	const hasCountryCode = 'country_code' in items;
-	const hasProvider = 'provider_id' in items;
+	const hasProvider = 'selected_provider_ids' in items;
 	const hasStatus = 'filter_status' in items;
 
 	if (hasCountryCode) {
 		countryCode = items.country_code;
 	}
 	if (hasProvider) {
-		selectedProviderIds = [items.provider_id]; //TODO: pass full list of selected providers
+		selectedProviderIds = items.selected_provider_ids;
 	}
 	if (hasStatus) {
 		filterStatus = items.filter_status;
@@ -154,8 +154,8 @@ async function loadDefaultSettings(needCountryCode, needProvider, needStatus) {
 		toStore.country_code = countryCode;
 	}
 	if (needProvider && 'provider_id' in result.json) {
-		selectedProviderIds = [result.json.provider_id]; //TODO: pass full list of selected providers
-		toStore.provider_id = selectedProviderIds[0];
+		selectedProviderIds = [result.json.provider_id];
+		toStore.selected_provider_ids = selectedProviderIds;
 	}
 	if (needStatus && 'filter_status' in result.json) {
 		filterStatus = result.json.filter_status;

--- a/extension/worker.js
+++ b/extension/worker.js
@@ -22,7 +22,7 @@ const MAX_CRAWL_RETRIES = 3;
 
 // settings
 let countryCode = ''; // e.g. German: "DE", USA: "US"
-let providerId = 0; // e.g. Netflix: 8, Amazon Prime Video: 9
+let selectedProviderIds = []; // e.g. Netflix: 8, Amazon Prime Video: 9
 let filterStatus = false;
 
 // fetch options
@@ -121,7 +121,7 @@ async function parseSettings(items) {
 		countryCode = items.country_code;
 	}
 	if (hasProvider) {
-		providerId = items.provider_id;
+		selectedProviderIds = [items.provider_id]; //TODO: pass full list of selected providers
 	}
 	if (hasStatus) {
 		filterStatus = items.filter_status;
@@ -154,8 +154,8 @@ async function loadDefaultSettings(needCountryCode, needProvider, needStatus) {
 		toStore.country_code = countryCode;
 	}
 	if (needProvider && 'provider_id' in result.json) {
-		providerId = result.json.provider_id;
-		toStore.provider_id = providerId;
+		selectedProviderIds = [result.json.provider_id]; //TODO: pass full list of selected providers
+		toStore.provider_id = selectedProviderIds[0];
 	}
 	if (needStatus && 'filter_status' in result.json) {
 		filterStatus = result.json.filter_status;
@@ -469,7 +469,7 @@ function addMovieIfFlatrate(results, tabId, letterboxdId) {
 	];
 
 	const hasProvider = offersToCheck.some(offer =>
-		offer.provider_id && offer.provider_id === providerId
+		offer.provider_id && selectedProviderIds.includes(offer.provider_id)
 	);
 
 	if (hasProvider) {

--- a/extension/worker.js
+++ b/extension/worker.js
@@ -251,7 +251,7 @@ browser.alarms.onAlarm.addListener(alarm => {
 /////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * Called to force the filters to reload with the new provider ID.
+ * Called to force the filters to reload with the new selected provider IDs.
  */
 async function reloadMovieFilter() {
 	const tabs = await browser.tabs.query({}) ?? [];
@@ -451,7 +451,7 @@ function extractMediaInfo(item, mediaType) {
 
 /**
  * Adds the given letterboxd ID to the availableMovies
- * if the selected provider includes the movie in its flatrate.
+ * if any of the selected providers includes the movie in its flatrate.
  *
  * @param {object} results - The results from the TMDB "Watch Providers" request.
  * @param {number} tabId - The tabId to operate in.
@@ -622,7 +622,7 @@ async function prepareLetterboxdForFading(tabId) {
 }
 
 /**
- * Fades out movies that are not available on the selected streaming provider.
+ * Fades out movies that are not available on any of the selected streaming providers.
  *
  * @param {number} tabId - The tabId to operate in.
  * @param {object} movies - The crawled movies.

--- a/extension/worker.js
+++ b/extension/worker.js
@@ -109,19 +109,26 @@ async function requestProviderList() {
 
 /**
  * Parses settings from storage items.
+ * Migrates the legacy single `provider_id` setting to `selected_provider_ids` if needed.
  *
  * @param {object} items - Storage items containing settings.
  */
 async function parseSettings(items) {
 	const hasCountryCode = 'country_code' in items;
-	const hasProvider = 'selected_provider_ids' in items;
+	const hasSelectedProviders = 'selected_provider_ids' in items;
+	const hasLegacyProvider = !hasSelectedProviders && 'provider_id' in items;
+	const hasProvider = hasSelectedProviders || hasLegacyProvider;
 	const hasStatus = 'filter_status' in items;
 
 	if (hasCountryCode) {
 		countryCode = items.country_code;
 	}
-	if (hasProvider) {
+	if (hasSelectedProviders) {
 		selectedProviderIds = items.selected_provider_ids;
+	} else if (hasLegacyProvider) {
+		selectedProviderIds = [items.provider_id];
+		browser.storage.local.set({selected_provider_ids: selectedProviderIds});
+		browser.storage.local.remove('provider_id');
 	}
 	if (hasStatus) {
 		filterStatus = items.filter_status;
@@ -138,10 +145,10 @@ async function parseSettings(items) {
  * Loads default settings from JSON file.
  *
  * @param {boolean} needCountryCode - Whether to load default country code.
- * @param {boolean} needProvider - Whether to load default provider.
+ * @param {boolean} needSelectedProviders - Whether to load default selected providers.
  * @param {boolean} needStatus - Whether to load default filter status.
  */
-async function loadDefaultSettings(needCountryCode, needProvider, needStatus) {
+async function loadDefaultSettings(needCountryCode, needSelectedProviders, needStatus) {
 	const result = await safeFetchJson("settings/default.json", {}, "default settings");
 	if (!result?.json) {
 		return;
@@ -153,8 +160,8 @@ async function loadDefaultSettings(needCountryCode, needProvider, needStatus) {
 		countryCode = result.json.country_code;
 		toStore.country_code = countryCode;
 	}
-	if (needProvider && 'provider_id' in result.json) {
-		selectedProviderIds = [result.json.provider_id];
+	if (needSelectedProviders && 'selected_provider_ids' in result.json) {
+		selectedProviderIds = result.json.selected_provider_ids;
 		toStore.selected_provider_ids = selectedProviderIds;
 	}
 	if (needStatus && 'filter_status' in result.json) {


### PR DESCRIPTION
Ports #13 by @samuelkcrow onto current main, keeping the original commits and author, and finishes off the loose ends that were left in that PR.

- Popup's streaming service picker becomes a multi-select (hold Ctrl/Cmd to pick more than one)
- Selections persist across sessions, reloads, and country changes via a new `selected_provider_ids` local storage key
- Legacy single `provider_id` setting is migrated automatically for existing installs
- Fixes the instruction text overlapping the "Streaming service" label under the new multi-select box
- README and version bump to reflect the new behavior