### PR TITLE
ci: add web-ext lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,33 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint extension with web-ext
+        run: |
+          # web-ext lint (Mozilla's official WebExtension linter,
+          # https://github.com/mozilla/web-ext) validates manifest.json
+          # structure/permissions, CSP, icons, etc. for MV3 manifests.
+          #
+          # extension/manifest.json is committed in its Chrome shape
+          # ("background.service_worker") and tools/build.sh swaps that to
+          # Firefox's "background.scripts" array at package time. Linting the
+          # committed manifest as-is would therefore always trip
+          # BACKGROUND_SERVICE_WORKER_NOFALLBACK -- a false positive caused by
+          # this repo's build-time toggle, not a real defect. So we lint a
+          # disposable copy with the same one-line swap tools/build.sh performs
+          # for the Firefox build, which exercises the same
+          # permissions/CSP/icons checks that apply to both browser targets.
+          #
+          # As of this writing extension/ lints completely clean under this
+          # scheme (0 errors, 0 warnings, 0 notices), so warnings are treated as
+          # errors too.
+          #
+          # The swap itself lives in tools/to-firefox-manifest.sh (the same
+          # script tools/build.sh uses for the real Firefox package), so this
+          # step and the build can't silently drift out of sync with each other.
+          cp -r extension "$RUNNER_TEMP/web-ext-lint-target"
+          bash tools/to-firefox-manifest.sh "$RUNNER_TEMP/web-ext-lint-target/manifest.json"
+          npx --yes web-ext@10.6.0 lint --source-dir="$RUNNER_TEMP/web-ext-lint-target" --warnings-as-errors
+
       - name: Write API config
         run: |
           python3 -c "

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -2,6 +2,7 @@
 echo "Building Extension"
 EXTENSIONNAME="Letterboxd-Streaming-Providers"
 DES=builds
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 TAG=$(date +"%y%m%d"_%H%M)
 
@@ -12,7 +13,7 @@ mkdir -p $DES
 cd extension/
 
 # Firefox build: replace service_worker with scripts array
-sed -i 's/"service_worker": "worker.js"/"scripts": ["worker.js"]/' manifest.json
+bash "$SCRIPT_DIR/to-firefox-manifest.sh" manifest.json
 zip -r ${FIREFOXFILENAME}.xpi *
 mv ${FIREFOXFILENAME}.xpi ../$DES/
 

--- a/tools/to-firefox-manifest.sh
+++ b/tools/to-firefox-manifest.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Swaps a manifest.json's MV3 background field from Chrome's
+# "service_worker" form to Firefox's "scripts" array form, in place.
+#
+# This is the one place this swap is implemented. tools/build.sh calls it to
+# produce the Firefox package, and .github/workflows/ci.yml's web-ext lint
+# step calls it against a disposable copy of the manifest so the two never
+# drift out of sync with each other.
+set -euo pipefail
+
+MANIFEST="${1:?usage: to-firefox-manifest.sh <path-to-manifest.json>}"
+
+sed -i 's/"service_worker": "worker.js"/"scripts": ["worker.js"]/' "$MANIFEST"


### PR DESCRIPTION
Added a new CI step to lint the extension using Mozilla's `web-ext` tool, ensuring the manifest and related files are valid for Firefox. This step uses a disposable copy of the manifest with the appropriate background script format for Firefox, and treats all warnings as errors to enforce strict compliance.